### PR TITLE
Parse Ruby blocks correctly. Fixes #1

### DIFF
--- a/lib/hamli/parser.rb
+++ b/lib/hamli/parser.rb
@@ -463,7 +463,7 @@ module Hamli
     def parse_broken_lines
       result = +''
       result << @scanner.scan(/[^\r\n]*/)
-      while result.end_with?(',') || result.end_with?('|')
+      while result.end_with?(',') || (result.end_with?('|') && (result !~ /\bdo\s*\|[^|]*\|\z/))
         syntax_error!(Errors::UnexpectedEosError) unless @scanner.scan(/\r?\n/)
 
         result << "\n"

--- a/spec/hamli/parser_spec.rb
+++ b/spec/hamli/parser_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe Hamli::Parser do
 
       it 'returns expected S-expression' do
         is_expected.to eq(
-          [:multi, [:hamli, :position, 2, 11, [:hamli, :control, false, 'a do |b|', [:multi]]]]
+          [:multi, [:hamli, :position, 2, 10, [:hamli, :control, false, 'a do |b|', [:multi, [:newline]]]]]
         )
       end
     end
@@ -497,6 +497,25 @@ RSpec.describe Hamli::Parser do
         is_expected.to eq(
           [:multi, [:hamli, :position, 3, 4, [:hamli, :output, false, 'a', [:multi, [:newline]]]]]
         )
+      end
+    end
+
+    context 'when using a block variable' do
+      let(:source) do
+        <<~HAML
+          - a do |b|
+            .row
+              .cell
+            .row
+              .cell
+        HAML
+      end
+
+      it 'returns expected S-expression' do
+        row = [:html, :tag, 'div', [:html, :attrs, [:html, :attr, 'class', [:static, 'row']]], [:multi, [:newline], [:html, :tag, 'div', [:html, :attrs, [:html, :attr, 'class', [:static, 'cell']]], [:multi, [:newline]]]]]
+        multi = [:multi, [:hamli, :position, 2, 10, [:hamli, :control, false, 'a do |b|', [:multi, [:newline], row, row]]]]
+
+        is_expected.to eq(multi)
       end
     end
   end


### PR DESCRIPTION
The parser used to continue reading (and expecting) Ruby lines
when a Ruby line ended in a backslash, e.g.

```haml
- a |
  b |
```

This behavior is incorrect when using Ruby block syntax, e.g.

```haml
- a do |b|
  .div
```

where the first HAML line after the Ruby line was read as
a continuation of the Ruby line, and the HAML parsing started
only at the second subsequent HAML line.

This misbehavior manifested in malformed indentation errors
when the subsequent HAML tree had more than one branch
at the root node.

We fix this by making the parser aware of Ruby block syntax.