### PR TITLE
Update actions/checkout from v2 to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         ruby:
           - 2.7.2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
I have cherry-picked parts of the following commit, as I believe these changes should be incorporated independently.

- https://github.com/r7kamura/hamli/pull/5

It was just getting too old, so I took this opportunity to update it. There isn't any significant intent behind the change.