### PR TITLE
Separate CI into RuboCop and RSpec jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  spec:
+  rspec:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake spec
+    - run: bundle exec rspec
 
   rubocop:
     runs-on: ubuntu-latest
@@ -29,4 +29,4 @@ jobs:
       with:
         ruby-version: 2.7.2
         bundler-cache: true
-    - run: bundle exec rake rubocop
+    - run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  build:
+  spec:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,4 +19,14 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - run: bundle exec rake
+    - run: bundle exec rake spec
+
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
+        bundler-cache: true
+    - run: bundle exec rake rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ruby
+        ruby-version: 2.7.2
         bundler-cache: true
     - run: bundle exec rake rubocop


### PR DESCRIPTION
To prepare for running CI with multiple Ruby versions in the future.

I have cherry-picked parts of the following commit, as I believe these changes should be incorporated independently.

- https://github.com/r7kamura/hamli/pull/5