### PR TITLE
Remove unnecessary `TargetRubyVersion`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,6 @@ plugins:
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.6
 
 Layout/LineLength:
   Enabled: false


### PR DESCRIPTION
I have cherry-picked parts of the following commit, as I believe these changes should be incorporated independently.

- https://github.com/r7kamura/hamli/pull/5