### PR TITLE
Drop support for Ruby versions earlier than 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.7.2
+          - '3.3'
+          - '3.4'
+          - '4.0'
     steps:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
@@ -27,6 +29,6 @@ jobs:
     - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: ruby
         bundler-cache: true
     - run: bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Drop support for Ruby versions earlier than 3.3.
+
 ## 0.5.1 - 2022-06-29
 
 ### Fixed

--- a/hamli.gemspec
+++ b/hamli.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'Yet another implementation for Haml template language.'
   spec.homepage = 'https://github.com/r7kamura/hamli'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 3.3.0'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage

--- a/lib/hamli/filters/interpolation.rb
+++ b/lib/hamli/filters/interpolation.rb
@@ -13,7 +13,7 @@ module Hamli
         scanner = ::StringScanner.new(string)
         until scanner.eos?
           charpos = scanner.charpos
-          if (value = scanner.scan(/\\#\{/)) # rubocop:disable Style/RedundantRegexpArgument
+          if (value = scanner.scan('\#{'))
             block << [:static, value]
           elsif scanner.scan(/#\{((?>[^{}]|(\{(?>[^{}]|\g<1>)*\}))*)\}/)
             code = scanner[1]

--- a/lib/hamli/parser.rb
+++ b/lib/hamli/parser.rb
@@ -223,7 +223,7 @@ module Hamli
     def parse_html_style_attributes
       @scanner.pos += 1
       result = []
-      until @scanner.scan(/\)/) # rubocop:disable Style/RedundantRegexpArgument
+      until @scanner.scan(')')
         syntax_error!(Errors::UnexpectedEosError) if @scanner.eos?
 
         @scanner.scan(/[ \t\r\n]+/)
@@ -245,7 +245,7 @@ module Hamli
       name = @scanner[1]
 
       @scanner.scan(/[ \t]*/)
-      return [:html, :attr, name, [:static, true]] unless @scanner.scan(/=/) # rubocop:disable Style/RedundantRegexpArgument
+      return [:html, :attr, name, [:static, true]] unless @scanner.scan('=')
 
       @scanner.scan(/[ \t]*/)
       unless (quote = @scanner.scan(/["']/))


### PR DESCRIPTION
I have cherry-picked parts of the following commit, as I believe these changes should be incorporated independently.

- https://github.com/r7kamura/hamli/pull/5